### PR TITLE
fix: fire events in the right order

### DIFF
--- a/api/src/main/java/net/starype/quiz/api/game/LeaderboardDistribution.java
+++ b/api/src/main/java/net/starype/quiz/api/game/LeaderboardDistribution.java
@@ -26,8 +26,9 @@ public class LeaderboardDistribution implements ScoreDistribution {
 
     @Override
     public Double apply(Player<?> player) {
-        if(leaderboard.getPosition(player).isEmpty()) {
-            return 0.0;
+        double score = leaderboard.getByPlayer(player).orElse(0.0);
+        if(score == 0.0) {
+            return score;
         }
 
         int position = leaderboard.getPosition(player).get();

--- a/api/src/main/java/net/starype/quiz/api/game/QuizGame.java
+++ b/api/src/main/java/net/starype/quiz/api/game/QuizGame.java
@@ -128,13 +128,6 @@ public interface QuizGame {
     void onRoundEnded(GameRound round);
 
     /**
-     * Perform actions after the guess has been processed by the {@code QuizRound}. This method is usually used to
-     * send the context to the server via the gate
-     * @param context the context returned by the {@code Round}
-     */
-    void onGuessContextReceived(PlayerGuessContext context);
-
-    /**
      * Determine whether the game is still running and accepting inputs
      * @return whether the game is over or not
      */

--- a/api/src/main/java/net/starype/quiz/api/game/QuizGame.java
+++ b/api/src/main/java/net/starype/quiz/api/game/QuizGame.java
@@ -128,6 +128,13 @@ public interface QuizGame {
     void onRoundEnded(GameRound round);
 
     /**
+     * Perform actions after the guess has been processed by the {@code QuizRound}. This method is usually used to
+     * send the context to the server via the gate
+     * @param context the context returned by the {@code Round}
+     */
+    void onGuessContextReceived(PlayerGuessContext context);
+
+    /**
      * Determine whether the game is still running and accepting inputs
      * @return whether the game is over or not
      */

--- a/api/src/main/java/net/starype/quiz/api/game/SimpleGame.java
+++ b/api/src/main/java/net/starype/quiz/api/game/SimpleGame.java
@@ -165,14 +165,6 @@ public class SimpleGame<T extends QuizGame> implements QuizGame {
     }
 
     @Override
-    public void onGuessContextReceived(PlayerGuessContext context) {
-        if(gate == null) {
-            return;
-        }
-        gate.callback(server -> server.onPlayerGuessed(context));
-    }
-
-    @Override
     public void sendInputToServer(Consumer<GameServer<?>> action) {
         if(gate == null) {
             return;

--- a/api/src/main/java/net/starype/quiz/api/game/SimpleGame.java
+++ b/api/src/main/java/net/starype/quiz/api/game/SimpleGame.java
@@ -161,7 +161,10 @@ public class SimpleGame<T extends QuizGame> implements QuizGame {
             gate.callback(server -> server.onPlayerGaveUp(player));
             return;
         }
-        PlayerGuessContext context = current.onGuessReceived(player, message);
+        current.onGuessReceived(player, message);
+    }
+
+    public void onGuessContextReceived(PlayerGuessContext context) {
         gate.callback(server -> server.onPlayerGuessed(context));
     }
 

--- a/api/src/main/java/net/starype/quiz/api/game/SimpleGame.java
+++ b/api/src/main/java/net/starype/quiz/api/game/SimpleGame.java
@@ -164,7 +164,11 @@ public class SimpleGame<T extends QuizGame> implements QuizGame {
         current.onGuessReceived(player, message);
     }
 
+    @Override
     public void onGuessContextReceived(PlayerGuessContext context) {
+        if(gate == null) {
+            return;
+        }
         gate.callback(server -> server.onPlayerGuessed(context));
     }
 

--- a/api/src/main/java/net/starype/quiz/api/round/QuizRound.java
+++ b/api/src/main/java/net/starype/quiz/api/round/QuizRound.java
@@ -1,10 +1,8 @@
 package net.starype.quiz.api.round;
 
 import net.starype.quiz.api.event.UpdatableHandler;
-import net.starype.quiz.api.game.PlayerGuessContext;
 import net.starype.quiz.api.game.QuizGame;
 import net.starype.quiz.api.player.Player;
-import net.starype.quiz.api.round.GameRound;
 
 import java.util.Collection;
 
@@ -12,7 +10,7 @@ public interface QuizRound extends GameRound {
 
     void start(QuizGame game, Collection<? extends Player<?>> players, UpdatableHandler eventHandler);
 
-    PlayerGuessContext onGuessReceived(Player<?> source, String message);
+    void onGuessReceived(Player<?> source, String message);
     void onGiveUpReceived(Player<?> source);
     default void onRoundStopped(){}
     void checkEndOfRound();

--- a/api/src/main/java/net/starype/quiz/api/round/StandardRound.java
+++ b/api/src/main/java/net/starype/quiz/api/round/StandardRound.java
@@ -7,10 +7,7 @@ import net.starype.quiz.api.game.*;
 import net.starype.quiz.api.player.Player;
 import net.starype.quiz.api.question.Question;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static net.starype.quiz.api.game.ScoreDistribution.Standing;
@@ -50,11 +47,8 @@ public class StandardRound implements QuizRound {
     public void start(QuizGame game, Collection<? extends Player<?>> players,
                       UpdatableHandler updatableHandler) {
         roundState.initPlayers(players);
-        if(game == null) {
-            throw new IllegalStateException("Game cannot be null");
-        }
+        this.game = Objects.requireNonNull(game, "Game cannot be null");
         game.sendInputToServer(server -> server.onQuestionReleased(pickedQuestion));
-        this.game = game;
         updatables.forEach(updatableHandler::registerEvent);
         updatables.forEach(event -> event.start(updatableHandler));
     }

--- a/api/src/test/java/net/starype/quiz/api/game/ClassicalRoundTest.java
+++ b/api/src/test/java/net/starype/quiz/api/game/ClassicalRoundTest.java
@@ -88,6 +88,7 @@ public class ClassicalRoundTest {
         round.onGuessReceived(player1, "correct");
         round.onGuessReceived(player2, "kinda-correct");
         round.onGuessReceived(player3, "pretty-correct");
+        round.onGuessReceived(player4, "incorrect");
 
         ScoreDistribution scoreDistribution = round.getScoreDistribution();
 


### PR DESCRIPTION
Now the guess context is sent to the server before checking the end of the round